### PR TITLE
Calculate flux of N-layered solutions using automatic differentiation

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -10,16 +10,29 @@ fluence_DA_inf_TD
 ```@docs
 fluence_DA_semiinf_CW
 fluence_DA_semiinf_TD
+flux_DA_semiinf_CW
+flux_DA_semiinf_TD
 ```
 
 ## Slab
 ```@docs
 fluence_DA_slab_CW
 fluence_DA_slab_TD
+flux_DA_slab_CW
+flux_DA_slab_TD
 ```
 
 ## Parallelepiped
 ```@docs
 fluence_DA_paralpip_CW
 fluence_DA_paralpip_TD
+```
+
+## Layered Cylinder
+```@docs
+fluence_DA_Nlay_cylinder_CW
+fluence_DA_Nlay_cylinder_TD
+
+flux_DA_Nlay_cylinder_CW
+flux_DA_Nlay_cylinder_TD
 ```

--- a/src/LightPropagation.jl
+++ b/src/LightPropagation.jl
@@ -8,29 +8,51 @@ using FFTW
 using Parameters
 using SpecialFunctions
 using JLD
+using ForwardDiff
 
 export TPSF_DA_semiinf_refl
 export TPSF_DA_slab_refl
 export TPSF_DA_paralpip_refl
 
+### Diffusion Theory
+
+# Infinite
 export fluence_DA_inf_CW
 export fluence_DA_inf_TD
+
+# Semi-infinite
 export fluence_DA_semiinf_TD
 export fluence_DA_semiinf_CW
+
+export flux_DA_semiinf_CW
+export flux_DA_semiinf_TD
+
+# Slab
 export fluence_DA_slab_CW
 export fluence_DA_slab_TD
+
+export flux_DA_slab_CW
+export flux_DA_slab_TD
+
+# Parallelepiped
 export fluence_DA_paralpip_TD
 export fluence_DA_paralpip_CW
 
-export Nlayer_cylinder
+# Layered cylinder
 export fluence_DA_Nlay_cylinder_CW
 export fluence_DA_Nlay_cylinder_TD
+
+export flux_DA_Nlay_cylinder_CW
+export flux_DA_Nlay_cylinder_TD
+
+# Structures
+export Nlayer_cylinder
+
+# constants
 export besselroots
 
 export getfit
-
 export load_asc_data
-
 export fitDTOF, DTOF_fitparams
 
 include("forwardmodels/Diffusion Approximation/diffusionparameters.jl")

--- a/src/forwardmodels/Diffusion Approximation/Semi-infinite/DAsemiinf.jl
+++ b/src/forwardmodels/Diffusion Approximation/Semi-infinite/DAsemiinf.jl
@@ -78,7 +78,7 @@ function fluence_DA_semiinf_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0
 	elseif isa(t, AbstractVector)
         T = promote_type(eltype(ρ), eltype(μa), eltype(μsp), eltype(z))
         ϕ = zeros(T, length(t))
-        
+
         @inbounds Threads.@threads for ind in eachindex(t)
     		ϕ[ind] = _kernel_fluence_DA_semiinf_TD(D, ν, t[ind], μa, z, z0, ρ, zb)
     	end
@@ -173,7 +173,6 @@ function flux_DA_semiinf_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0)
 
     return Rt
 end
-
 
 #####################################
 # Steady-State Flux

--- a/src/forwardmodels/Diffusion Approximation/Slab/DAslab.jl
+++ b/src/forwardmodels/Diffusion Approximation/Slab/DAslab.jl
@@ -232,12 +232,10 @@ end
 # Steady-State Flux
 #####################################
 """
-fluence_DA_slab_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, s = 2.0, z = 0.0, xs = 10)
+    fluence_DA_slab_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, s = 2.0, z = 0.0, xs = 10)
 
-    flux_DA_slab_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, s = 2.0, z = 0.0, xs = 10)
-
-Compute the steady-state flux, D*∂ϕ(ρ)/∂z for z = 0 and -D*∂ϕ(ρ)/∂z for z = s from a slab geometry (x, y -> inf, z -> finite).
-If z != 0 or s will default to compute D*∂ϕ(ρ)/∂z for the z given.
+    Compute the steady-state flux, D*∂ϕ(ρ)/∂z for z = 0 and -D*∂ϕ(ρ)/∂z for z = s from a slab geometry (x, y -> inf, z -> finite).
+    If z != 0 or s will default to compute D*∂ϕ(ρ)/∂z for the z given.
 
 # Arguments
 - `ρ`: the source detector separation (cm⁻¹)

--- a/src/forwardmodels/Diffusion Approximation/Slab/DAslab.jl
+++ b/src/forwardmodels/Diffusion Approximation/Slab/DAslab.jl
@@ -124,7 +124,8 @@ end
 """
     flux_DA_slab_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, s = 1.0, z = 0.0, xs = 15)
 
-    Compute the time-domain flux (D*∂ϕ(t)/∂z @ z = 0 or z = s) from a slab geometry (x,y->inf, z-> finite). 
+    Compute the time-domain flux, D*∂ϕ(t)/∂z for z = 0 and -D*∂ϕ(t)/∂z for z = s from a slab geometry (x, y -> inf, z -> finite).
+    If z != 0 or s will default to compute D*∂ϕ(t)/∂z for the z given. 
 
 # Arguments
 - `t`: the time vector (ns). 
@@ -235,7 +236,8 @@ fluence_DA_slab_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, s = 2.0, z = 0.0, xs
 
     flux_DA_slab_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, s = 2.0, z = 0.0, xs = 10)
 
-Compute the steady-state flux (D*∂ϕ(ρ)/∂z for z = 0 or s from a slab geometry (x, y -> inf, z -> finite). 
+Compute the steady-state flux, D*∂ϕ(ρ)/∂z for z = 0 and -D*∂ϕ(ρ)/∂z for z = s from a slab geometry (x, y -> inf, z -> finite).
+If z != 0 or s will default to compute D*∂ϕ(ρ)/∂z for the z given.
 
 # Arguments
 - `ρ`: the source detector separation (cm⁻¹)

--- a/src/forwardmodels/Diffusion Approximation/Slab/DAslab.jl
+++ b/src/forwardmodels/Diffusion Approximation/Slab/DAslab.jl
@@ -235,7 +235,7 @@ fluence_DA_slab_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, s = 2.0, z = 0.0, xs
 
     flux_DA_slab_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, s = 2.0, z = 0.0, xs = 10)
 
-Compute the steady-state flux (D*∂ϕ(ρ)/∂z for z = [0, s]) from a slab geometry (x, y -> inf, z -> finite). 
+Compute the steady-state flux (D*∂ϕ(ρ)/∂z for z = 0 or s from a slab geometry (x, y -> inf, z -> finite). 
 
 # Arguments
 - `ρ`: the source detector separation (cm⁻¹)

--- a/src/forwardmodels/Diffusion Approximation/Slab/DAslab.jl
+++ b/src/forwardmodels/Diffusion Approximation/Slab/DAslab.jl
@@ -226,3 +226,39 @@ end
 
 	return Rt1 * Rt2  
 end
+
+#####################################
+# Steady-State Flux
+#####################################
+"""
+fluence_DA_slab_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, s = 2.0, z = 0.0, xs = 10)
+
+    flux_DA_slab_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, s = 2.0, z = 0.0, xs = 10)
+
+Compute the steady-state flux (D*∂ϕ(ρ)/∂z for z = [0, s]) from a slab geometry (x, y -> inf, z -> finite). 
+
+# Arguments
+- `ρ`: the source detector separation (cm⁻¹)
+- `μa`: absorption coefficient (cm⁻¹)
+- `μsp`: reduced scattering coefficient (cm⁻¹)
+- `n_ext`: the boundary's index of refraction (air or detector)
+- `n_med`: the sample medium's index of refraction
+- `s`: the thickness (z-depth) of the slab (cm)
+- `z`: the z-depth within slab (cm)
+- `xs`: the number of sources to compute in the series
+
+# Examples
+```jldoctest
+julia> `flux_DA_slab_CW(1.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0, s = 2.0, z = 0.0)`
+```
+"""
+function flux_DA_slab_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, s = 2.0, z = 0.0, xs = 10)
+    D = D_coeff(μsp, μa)
+    if z == zero(eltype(z))
+        return D * ForwardDiff.derivative(dz -> fluence_DA_slab_CW(ρ, μa, μsp, n_med = n_med, n_ext = n_ext, s = s, z = dz, xs = xs), z)
+    elseif z == s
+        return -D * ForwardDiff.derivative(dz -> fluence_DA_slab_CW(ρ, μa, μsp, n_med = n_med, n_ext = n_ext, s = s, z = dz, xs = xs), z)
+    else 
+        return D * ForwardDiff.derivative(dz -> fluence_DA_slab_TD(t, ρ, μa, μsp, n_ext = n_ext, n_med = n_med, s = s, z = dz, xs = xs), z)
+    end
+end

--- a/test/DA_NlayerTests/DA_Nlayer_functionTests.jl
+++ b/test/DA_NlayerTests/DA_Nlayer_functionTests.jl
@@ -145,4 +145,29 @@ a96 = fluence_DA_Nlay_cylinder_TD(t, cylinder_data, bessels = besselroots[1:600]
 @test a72 ≈ slab
 @test a96 ≈ slab
 
+
+### Flux tests
+
+# CW 
+cylinder_data = Nlayer_cylinder(ρ = 1.0, μsp = [10.0, 10.0], μa = [0.1, 0.1], l = [10.0, 10.0], n_med = [1.0, 1.0], n_ext = 1.0, a = 40.0)
+@test flux_DA_Nlay_cylinder_CW(cylinder_data, besselroots[1:10000]) ≈ flux_DA_semiinf_CW(1.0, 0.1, 10.0; n_ext = 1.0, n_med = 1.0)
+
+cylinder_data = Nlayer_cylinder(ρ = 1.0, μsp = [10.0, 10.0], μa = [0.1, 0.1], l = [2.0, 2.0], z = 4.0, n_med = [1.0, 1.0], n_ext = 1.0, a = 40.0)
+@test flux_DA_Nlay_cylinder_CW(cylinder_data, besselroots[1:10000]) ≈ flux_DA_slab_CW(1.0, 0.1, 10.0; n_ext = 1.0, n_med = 1.0, s = 4.0, z = 4.0, xs = 15)
+
+# TD
+t = 1.0
+cylinder_data = Nlayer_cylinder(ρ = 1.0, μsp = [10.0, 10.0], μa = [0.1, 0.1], l = [10.0, 10.0], n_med = [1.0, 1.0], n_ext = 1.0, a = 40.0)
+@test flux_DA_Nlay_cylinder_TD(t, cylinder_data, bessels = besselroots[1:10000]) ≈ flux_DA_semiinf_TD(t, 1.0, 0.1, 10.0; n_ext = 1.0, n_med = 1.0)
+
+cylinder_data = Nlayer_cylinder(ρ = 1.0, μsp = [10.0, 10.0], μa = [0.1, 0.1], l = [2.0, 2.0], z = 4.0, n_med = [1.0, 1.0], n_ext = 1.0, a = 40.0)
+@test flux_DA_Nlay_cylinder_TD(t, cylinder_data, bessels = besselroots[1:10000]) ≈ flux_DA_slab_TD(t, 1.0, 0.1, 10.0; n_ext = 1.0, n_med = 1.0, s = 4.0, z = 4.0, xs = 15)
+
+t = 0.5:0.1:1.5
+cylinder_data = Nlayer_cylinder(ρ = 1.0, μsp = [10.0, 10.0], μa = [0.1, 0.1], l = [10.0, 10.0], n_med = [1.0, 1.0], n_ext = 1.0, a = 40.0)
+@test flux_DA_Nlay_cylinder_TD(t, cylinder_data, bessels = besselroots[1:10000]) ≈ flux_DA_semiinf_TD(t, 1.0, 0.1, 10.0; n_ext = 1.0, n_med = 1.0)
+
+cylinder_data = Nlayer_cylinder(ρ = 1.0, μsp = [10.0, 10.0], μa = [0.1, 0.1], l = [2.0, 2.0], z = 4.0, n_med = [1.0, 1.0], n_ext = 1.0, a = 40.0)
+@test flux_DA_Nlay_cylinder_TD(t, cylinder_data, bessels = besselroots[1:10000]) ≈ flux_DA_slab_TD(t, 1.0, 0.1, 10.0; n_ext = 1.0, n_med = 1.0, s = 4.0, z = 4.0, xs = 15)
+
 end # module

--- a/test/DAsemiinfTests/runtests.jl
+++ b/test/DAsemiinfTests/runtests.jl
@@ -16,4 +16,8 @@ using LightPropagation: fluence_DA_semiinf_CW, fluence_DA_semiinf_TD
 d = [0.000288659079311426, 2.896685181887841e-6, 5.474977667638328e-8, 1.3595622802163355e-9]
 @test fluence_DA_semiinf_TD(1.0:4.0, 1.0, 0.1, 10.0, n_med = 1.0, n_ext = 1.0, z = 0.0) ≈ d
 
+# this test both the ForwardDiff package and the implementations of fluence and flux in semiinfite case
+D = 1 / (3 * 10.0) # hard code diffusion coefficient here but could be different
+@test D*ForwardDiff.derivative(z -> fluence_DA_semiinf_TD(1.0, 1.0, 0.1, 10.0, z = z), 0.0) ≈ flux_DA_semiinf_TD(1.0, 1.0, 0.1, 10.0, n_med = 1.0, n_ext = 1.0)
+
 end # module

--- a/test/DAslabTests/runtests.jl
+++ b/test/DAslabTests/runtests.jl
@@ -39,5 +39,7 @@ D = 1 / (3 * 20.0)
 D = 1 / (3 * 20.0)
 @test (-D * ForwardDiff.derivative(dz -> fluence_DA_slab_TD(1.0, 1.3, 0.3, 20.0, n_ext = 1.0, n_med = 1.0, s = 1.0, z = dz), 1.0)) ≈ flux_DA_slab_TD(1.0, 1.3, 0.3, 20.0,  n_ext = 1.0, n_med = 1.0, s = 1.0, z = 1.0)
 
+## CW
+@test flux_DA_slab_CW(1.0, 0.1, 10.0; n_ext = 1.0, n_med = 1.0, s = 40.0, z = 0.0, xs = 15) ≈ flux_DA_semiinf_CW(1.0, 0.1, 10.0; n_ext = 1.0, n_med = 1.0)
 
 end 

--- a/test/DAslabTests/runtests.jl
+++ b/test/DAslabTests/runtests.jl
@@ -8,33 +8,36 @@ using LightPropagation: refl_DA_slab_TD, trans_DA_slab_TD
 
 
 # Test slabs against semi-inf for sufficiently thick slabs
+fluence_DA_slab_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, s = 2.0, z = 0.0, xs = 10)
 
 # CW
-@test fluence_DA_slab_CW(1.0, 0.1, 10.0, 1.0, 1.0, 20.0, 0.0) == 0.024035998288332954
-@test fluence_DA_slab_CW(2.4, 0.6, 18.0, 1.3, 1.2, 15.0, 1.0) == 1.77784095787581e-7
-@test fluence_DA_semiinf_CW(1.0, 0.1, 10.0, 1.0, 1.0, 0.0) ≈ fluence_DA_slab_CW(1.0, 0.1, 10.0, 1.0, 1.0, 20.0, 0.0)
-@test fluence_DA_semiinf_CW(4.0, 0.01, 50.0, 1.0, 1.0, 0.0) ≈ fluence_DA_slab_CW(4.0, 0.01, 50.0, 1.0, 1.0, 20.0, 0.0)
+@test fluence_DA_slab_CW(1.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0, s = 20.0, z = 0.0) == 0.024035998288332954
+@test fluence_DA_slab_CW(2.4, 0.6, 18.0, n_ext = 1.3, n_med = 1.2, s = 15.0, z = 1.0) == 1.77784095787581e-7
+@test fluence_DA_semiinf_CW(1.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0, z = 0.0) ≈ fluence_DA_slab_CW(1.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0, z = 0.0, s = 20.0)
+@test fluence_DA_semiinf_CW(4.0, 0.01, 50.0, n_ext = 1.0, n_med = 1.0, z = 0.0) ≈ fluence_DA_slab_CW(4.0, 0.01, 50.0,n_ext = 1.0, n_med = 1.0, z = 0.0, s = 20.0)
 
 # TD
 t = 0.1:0.5:8
-@test fluence_DA_semiinf_TD(t, 1.0, 0.1, 10.0, 1.0, 1.0, 0.0) ≈ fluence_DA_slab_TD(t, 1.0, 0.1, 10.0, 1.0, 1.0, 40.0, 0.0)
-@test fluence_DA_semiinf_TD(t, 1.0, 0.01, 70.0, 1.0, 1.0, 0.0) ≈ fluence_DA_slab_TD(t, 1.0, 0.01, 70.0, 1.0, 1.0, 40.0, 0.0)
+@test fluence_DA_semiinf_TD(t, 1.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0, z = 0.0) ≈ fluence_DA_slab_TD(t, 1.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0, z = 0.0, s = 40.0)
+@test fluence_DA_semiinf_TD(t, 1.0, 0.01, 70.0, n_ext = 1.0, n_med = 1.0, z = 0.0) ≈ fluence_DA_slab_TD(t, 1.0, 0.01, 70.0, n_ext = 1.0, n_med = 1.0, z = 0.0, s = 40.0)
 
-@test fluence_DA_semiinf_TD(t, 3.0, 0.1, 10.0, 1.0, 1.0, 0.0) ≈ fluence_DA_slab_TD(t, 3.0, 0.1, 10.0, 1.0, 1.0, 40.0, 0.0)
-@test fluence_DA_semiinf_TD(t, 3.0, 0.01, 70.0, 1.0, 1.0, 0.0) ≈ fluence_DA_slab_TD(t, 3.0, 0.01, 70.0, 1.0, 1.0, 40.0, 0.0)
+@test fluence_DA_semiinf_TD(t, 3.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0, z = 0.0) ≈ fluence_DA_slab_TD(t, 3.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0, z = 0.0, s = 40.0)
+@test fluence_DA_semiinf_TD(t, 3.0, 0.01, 70.0, n_ext = 1.0, n_med = 1.0, z = 0.0) ≈ fluence_DA_slab_TD(t, 3.0, 0.01, 70.0, n_ext = 1.0, n_med = 1.0, z = 0.0, s = 40.0)
+@test fluence_DA_semiinf_TD(t, 3.0, 0.01, 70.0, n_ext = 1.4, n_med = 1.2, z = 0.1) ≈ fluence_DA_slab_TD(t, 3.0, 0.01, 70.0, n_ext = 1.4, n_med = 1.2, z = 0.1, s = 40.0)
 
 ## check flux
 
 # reflectance
+
 D = 1 / (3 * 10.0)
-@test (D * ForwardDiff.derivative(z -> fluence_DA_slab_TD(1.0, 1.0, 0.1, 10.0, 1.0, 1.0, 1.0, z), 0.0)) ≈ refl_DA_slab_TD(1.0, [0.1, 10.0], 1.0, 1.0, 1.0, 1.0)[1]
+@test (D * ForwardDiff.derivative(dz -> fluence_DA_slab_TD(1.0, 1.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0, s = 1.0, z = dz), 0.0)) ≈ flux_DA_slab_TD(1.0, 1.0, 0.1, 10.0,  n_ext = 1.0, n_med = 1.0, s = 1.0, z = 0.0)
 
 D = 1 / (3 * 20.0)
-@test (D * ForwardDiff.derivative(z -> fluence_DA_slab_TD(1.5, 1.0, 0.4, 20.0, 1.0, 1.0, 1.0, z), 0.0)) ≈ refl_DA_slab_TD(1.5, [0.4, 20.0], 1.0, 1.0, 1.0, 1.0)[1]
+@test (D * ForwardDiff.derivative(dz -> fluence_DA_slab_TD(1.0, 1.3, 0.3, 20.0, n_ext = 1.0, n_med = 1.0, s = 1.0, z = dz), 0.0)) ≈ flux_DA_slab_TD(1.0, 1.3, 0.3, 20.0,  n_ext = 1.0, n_med = 1.0, s = 1.0, z = 0.0)
 
 # transmittance
-
 D = 1 / (3 * 20.0)
-@test (-D * ForwardDiff.derivative(z -> fluence_DA_slab_TD(1.5, 1.0, 0.4, 20.0, 1.0, 1.0, 1.0, z), 1.0)) ≈ trans_DA_slab_TD(1.5, [0.4, 20.0], 1.0, 1.0, 1.0, 1.0)[1]
+@test (-D * ForwardDiff.derivative(dz -> fluence_DA_slab_TD(1.0, 1.3, 0.3, 20.0, n_ext = 1.0, n_med = 1.0, s = 1.0, z = dz), 1.0)) ≈ flux_DA_slab_TD(1.0, 1.3, 0.3, 20.0,  n_ext = 1.0, n_med = 1.0, s = 1.0, z = 1.0)
+
 
 end 


### PR DESCRIPTION
This creates and edits several new features:
1. (more straightforward) Allows for calculation of flux using fick's law for the steady-state case in the layered solution. This can be done fairly easily with `ForwardDiff` by a simple call like...
`ForwardDiff.derivative(dz -> fluence_DA_Nlay_cylinder_CW(ρ, μa, μsp, n_ext, n_med, l, a, dz, besselroots), z)`. This allows the fluence and flux to be calculated in the same computation time.
2. (more complicated) In the time domain an approach like for the steady-state could not be done quite as simply except for the case when `t` is just an AbstractFloat. However, if we want to calculate for many time points using `hyper_fixed` there were several errors to fix. The primary one being is that ForwardDiff uses Dual numbers that are embedded within the function arguments that are passed to `hyper_fixed`. There are several spots where `hyper_fixed` allocates before evaluated the function so did not know the type. There were a couple of options that were tried here. One was just to evaluate the anonymous function passed to `hyper_fixed` first for a single value then allocate based on those types. However, we want to be able to thread these solutions because the single evaluation is costly. Instead, I updated the `hyper_fixed` functions to create an optional input argument being the eltype to preallocate the vectors in `hyper_fixed` with. This is done with creating an intermediate function:
` function _ILT(z::T) where {T} 
        return hyper_fixed(s -> _fluence_DA_Nlay_cylinder_Laplace(ρ, μa, μsp, n_ext, n_med, l, a, z, s, besselroots), t, N = N, T = T)
    end` where now the type parameter of z which is what we are differentiating with respect to is known at compile time an d fed to `hyper_fixed`.
3. Several other edits to the semi-inf and slab cases for flux were also exported.