### PR TITLE
Improve numerical accuracy of steady-state and time-domain fluence for semi-infinite media

### DIFF
--- a/src/forwardmodels/Diffusion Approximation/Infinite/DAinfinite.jl
+++ b/src/forwardmodels/Diffusion Approximation/Infinite/DAinfinite.jl
@@ -5,68 +5,10 @@
 # [1] Patterson et. al., "Time resolved reflectance and transmittance for the noninvasive measurement of tissue optical properties," 
 #     Appl. Opt. 28, 2331-2336 (1989)
 #-------------------------------------------------------------------------------------------------------------------------
-""" Structure containing inputs for simulating the fluence under the diffusion approximation in the infinite space."""
-struct DAinf_params{T <: AbstractFloat} <: DiffusionParameters
-    ρ::T                                 # distance away from isotropic point source (cm)
-    μa::T                                # absorption coefficient (cm⁻¹)
-    μsp::T                               # reduced scattering coefficient (cm⁻¹)
-    n_med::T                             # medium's index of refraction
-    ω::T                                 # modulation frequency (1/ns)
-    t::Union{T, AbstractVector{T}}       # time vector (ns)
-
-    # do not need to provide these arguments (calculated from previous inputs)
-    D::T                                 # Diffusion coefficient                        
-    ν::T                                 # Speed of light in medium (cm/ns)
-    function DAinf_params{T}(ρ::T, μa::T, μsp::T, n_med::T, ω::T, t::Union{T, AbstractVector{T}}) where {T <: AbstractFloat}
-        @assert ρ > zero(T) "ρ must be positive"
-        @assert μa >= zero(T) "μa must greater than or equal to 0"
-        @assert μsp > zero(T) "μsp must greater than 0"
-        @assert n_med > zero(T) "n_med must be positive"
-        @assert all(t .> zero(T)) "t must be positive"
-        return new{T}(ρ, μa, μsp, n_med, ω, t, D_coeff(μsp), ν_coeff(n_med))
-    end
-end
-
-"""
-    Generator function for DAinf_params structure.
-
-Provides parameters to use in the infinite space fluence calculation in either the CW, FD, or TD.
-Arguments are given as keyword arguments (key = value)
-
-# Keyword Arguments
-- `ρ`: source-detector separation (cm⁻¹)
-- `μa`: absorption coefficient (cm⁻¹)
-- `μsp`: reduced scattering coefficient (cm⁻¹)
-- `n_med`: medium's index of refraction
-- `ω`: modulation frequency (1/ns)
-- `t`: the time vector (ns). 
-
-# Examples
-```
-julia> data = DAinf_params() # return default parameters
-julia> data = DAinf_params(ρ = 1.5) # return ρ = 1.5 with the rest of the parameters given by defaults
-julia> fluence_DA_inf_CW(data) # can then be used with corresponding functions
-```
-"""
-function DAinf_params(;
-    ρ::T = 1.0,
-    μa::T = 0.1,
-    μsp::T = 10.0,
-    n_med::T = 1.0,
-    ω::T = 0.0,
-    t::Union{T, AbstractVector{T}} = 1.0
-) where {T<:AbstractFloat}
-    return DAinf_params{T}(ρ, μa, μsp, n_med, ω, t)
-end
-
-#-------------------------------------
-# Steady-State Fluence 
-#-------------------------------------
 """
     fluence_DA_inf_CW(ρ, μa, μsp)
 
 Compute the steady-state fluence in an infinite medium.
-This is an unsafe implementation and will not check parameters. ρ and μsp should be > 0.0 and μa >= 0.0.
 
 # Arguments
 - `ρ`: source-detector separation (cm⁻¹)
@@ -78,30 +20,8 @@ This is an unsafe implementation and will not check parameters. ρ and μsp shou
 julia> fluence_DA_inf_CW(1.0, 0.1, 10.0)
 ```
 """
-function fluence_DA_inf_CW(ρ, μa, μsp)
-    params = DiffusionKernelParams(μsp)
-    return _kernel_fluence_DA_inf_CW(ρ, μa, μsp, params.D)
-end
-"""
-    fluence_DA_inf_CW(data::DiffusionParameters)
+function fluence_DA_inf_CW end
 
-Wrapper to `fluence_DA_inf_CW(ρ, μa, μsp)`
-
-# Examples
-```
-julia> data = DAinf_params(ρ = 1.0) # use structure to generate inputs
-julia> fluence_DA_inf_CW(data) # then call the function
-```
-"""
-function fluence_DA_inf_CW(data::DiffusionParameters)
-    return _kernel_fluence_DA_inf_CW(data.ρ, data.μa, data.μsp, data.D)
-end
-
-_kernel_fluence_DA_inf_CW(ρ, μa, μsp, D) = exp(-sqrt(3 * μsp * μa) * ρ) / (4 * π * ρ * D)
-
-#-------------------------------------
-# Frequency-Domain Fluence 
-#-------------------------------------
 """
     fluence_DA_inf_FD(ρ, μa, μsp; ω = 0.0, n_med = 1.0)
 
@@ -121,35 +41,12 @@ Compute the fluence for a frequency modulated source in an infinite medium.
 julia> fluence_DA_inf_FD(1.0, 0.1, 10.0, ω = 1.0, n_med = 1.4)
 ```
 """
-function fluence_DA_inf_FD(ρ, μa, μsp; ω = 0.0, n_med = 1.0)
-    params = DiffusionKernelParams(μsp, n_med)
-    μa_complex = μa + ω * im / params.ν
-    return _kernel_fluence_DA_inf_CW(ρ, μa_complex, μsp, params.D)
-end
-"""
-    fluence_DA_inf_FD(data::DiffusionParameters)
+function fluence_DA_inf_FD end
 
-Wrapper to `fluence_DA_inf_FD(ρ, μa, μsp; ω = 0.0, n_med = 1.0)`
-
-# Examples
-```
-julia> data = DAinf_params(ω = 1.0) # use structure to generate inputs
-julia> fluence_DA_inf_FD(data) # then call the function
-```
-"""
-function fluence_DA_inf_FD(data::DiffusionParameters)
-    μa_complex = data.μa + data.ω * im / data.ν
-    return _kernel_fluence_DA_inf_CW(data.ρ, μa_complex, data.μsp, data.D)
-end
-
-#-------------------------------------
-# Time-Domain Fluence 
-#-------------------------------------
 """
     fluence_DA_inf_TD(t, ρ, μa, μsp; n_med = 1.0)
 
-Compute the time-domain fluence in an infinite medium with Eqn. 3 of Patterson. et al. 1989.
-This is an unsafe implementation and will not check parameters. t, ρ and μsp should be > 0.0 and μa >= 0.0.
+Compute the time-domain fluence in an infinite medium.
 
 # Arguments
 - `t`: the time vector (ns). 
@@ -162,28 +59,40 @@ This is an unsafe implementation and will not check parameters. t, ρ and μsp s
 
 # Examples
 ```
+julia> fluence_DA_inf_TD(0.1, 1.0, 0.1, 10.0, n_med = 1.4)
 julia> fluence_DA_inf_TD(0.1:0.5:5.0, 1.0, 0.1, 10.0, n_med = 1.4)
 ```
 """
+function fluence_DA_inf_TD end
+
+
+#-------------------------------------
+# Steady-State Fluence 
+#-------------------------------------
+
+function fluence_DA_inf_CW(ρ, μa, μsp)
+    D = D_coeff(μsp)
+    return exp(-sqrt(3 * μsp * μa) * ρ) / (4 * π * ρ * D)
+end
+
+#-------------------------------------
+# Frequency-Domain Fluence 
+#-------------------------------------
+
+function fluence_DA_inf_FD(ρ, μa, μsp; ω = 0.0, n_med = 1.0)
+    ν = ν_coeff(n_med)
+    μa_complex = μa + ω * im / ν
+    return fluence_DA_inf_CW(ρ, μa_complex, μsp)
+end
+
+#-------------------------------------
+# Time-Domain Fluence 
+#-------------------------------------
+
 function fluence_DA_inf_TD(t, ρ, μa, μsp; n_med = 1.0)
-    params = DiffusionKernelParams(μsp, n_med)
-    return map(t -> _kernel_fluence_DA_inf_TD(t, ρ, μa, params.ν, params.D), t)
+    D, ν = D_coeff(μsp), ν_coeff(n_med)
+    return map(t -> _kernel_fluence_DA_inf_TD(t, ρ, μa, ν, D), t)
 end
-"""
-    fluence_DA_inf_TD(data::DiffusionParameters)
-
-Wrapper to `fluence_DA_inf_TD(t, ρ, μa, μsp; n_med = 1.0)`.
-
-# Examples
-```
-julia> data = DAinf_params(t = 0.1:0.05:2.0) # use structure to generate inputs
-julia> fluence_DA_inf_TD(data) # then call the function
-```
-"""
-function fluence_DA_inf_TD(data::DiffusionParameters)
-    return map(t -> _kernel_fluence_DA_inf_TD(t, data.ρ, data.μa, data.ν, data.D), data.t)
-end
-
 @inline function _kernel_fluence_DA_inf_TD(t, ρ, μa, ν, D)
     tmp1 = 4 * D * ν * t
     ϕ = exp(-(ρ^2 / tmp1) - μa * ν * t)

--- a/src/forwardmodels/Diffusion Approximation/Semi-infinite/DAsemiinf.jl
+++ b/src/forwardmodels/Diffusion Approximation/Semi-infinite/DAsemiinf.jl
@@ -1,10 +1,9 @@
 #----------------------------------------------------------------------------------------------------------------------------------------
-# Implements solution to the diffusion equation for the fluence in the steady-state and time-domain in a semi-infinite medium [1][2][3].
+# Implements solutions to the diffusion equation for the fluence in the steady-state and time-domain in a semi-infinite medium using
+# equations 1, 3, 5, and 6 from Kienle and Patterson [1].
 #
 # [1] Alwin Kienle and Michael S. Patterson, "Improved solutions of the steady-state and the time-resolved diffusion equations 
 #     for reflectance from a semi-infinite turbid medium," J. Opt. Soc. Am. A 14, 246-254 (1997) 
-# [2] Martelli, Fabrizio, et al. Light propagation through biological tissue and other diffusive media: theory, solutions and software. 
-#     Vol. 10. No. 3.824746. Bellingham: SPIE press, 2010.
 #----------------------------------------------------------------------------------------------------------------------------------------
 """
     fluence_DA_semiinf_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0)
@@ -38,6 +37,8 @@ Compute the steady-state flux (D*∂ϕ(ρ)/∂z @ z = 0) from a semi-infinite me
 - `ρ`: the source detector separation (cm⁻¹)
 - `μa`: absorption coefficient (cm⁻¹)
 - `μsp`: reduced scattering coefficient (cm⁻¹)
+
+# Keyword arguments
 - `ndet`: the boundary's index of refraction (air or detector)
 - `nmed`: the sample medium's index of refraction
 
@@ -98,7 +99,7 @@ function fluence_DA_semiinf_TD end
 """
     flux_DA_semiinf_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0)
 
-Compute the time-domain flux (D*∂ϕ(t)/∂z @ z = 0) from a semi-infinite medium from Eqn. 36 Contini 97 (m = 0).
+Compute the time-domain flux (D*∂ϕ(t)/∂z @ z = 0) in a semi-infinite medium.
 
 # Arguments
 - `t`: the time vector (ns). 
@@ -132,7 +133,6 @@ function _kernel_fluence_DA_semiinf_CW(μeff, ρ, z, z0, zb, D)
     b = hypot(ρ, z + 2 * zb + z0)
 
     # the following tries to compute ϕ = exp(-μeff * a) / a - exp(-μeff * b) / b more accurately
-    # there is some loss of significance when a ≈ b and a > 5
     # h also tries to compute h = b - a more accurately
     h = 4 * (z0 * z + z0 * zb + z * zb + zb^2) / (a + b)
     ϕ = exp(-b * μeff) * fma(b, expm1(h * μeff), h) / (b * a)
@@ -150,8 +150,18 @@ end
 #------------------------------
 
 function flux_DA_semiinf_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0)
-    D = D_coeff(μsp)
-    return D * ForwardDiff.derivative(z -> fluence_DA_semiinf_CW(ρ, μa, μsp, n_med = n_med, n_ext = n_ext, z = z), 0.0)
+    T = eltype(ρ)
+
+    μeff = sqrt(3 * μa * μsp)
+    D, A = D_coeff(μsp), A_coeff(n_med / n_ext)
+    z0, zb = z0_coeff(μsp), zb_coeff(A, D)
+
+    a = hypot(z0, ρ)
+    b = hypot(z0 + 2*zb, ρ)
+    ϕ = z0 * (μeff + inv(a)) * exp(-μeff * a) / a^2
+    ϕ += (z0 + 2*zb) * (μeff + inv(b)) * exp(-μeff * b) / b^2
+
+    return ϕ / (4 * T(π))
 end
 
 #------------------------------
@@ -197,17 +207,18 @@ function flux_DA_semiinf_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0)
     D, A, ν = D_coeff(μsp), A_coeff(n_med / n_ext), ν_coeff(n_med)
     z0, zb = z0_coeff(μsp), zb_coeff(A, D)
 
-    z3m = -z0
-    z4m = 2 * zb + z0
+    a = hypot(z0, ρ)^2
+    b = hypot(z0 + 2 * zb, ρ)^2
 
-    return map(t -> _kernel_flux_DA_semiinf_TD(D, ν, t, μa, z3m, z4m, ρ), t)
- end
-@inline function _kernel_flux_DA_semiinf_TD(D, ν, t, μa, z3m, z4m, ρ)
-    tmp1 = 4 * D * ν * t
-    Rt = -(ρ^2 / (tmp1))
-    Rt -= μa * ν * t
-    Rt = -exp(Rt) / (2 * (4 * π * D * ν)^(3/2) * sqrt(t * t * t * t * t))
-    Rt *= (z3m * exp(-(z3m^2 / (tmp1))) - z4m * exp(-(z4m^2 / (tmp1))))
+    return  map(t -> _kernel_flux_DA_semiinf_TD(D, ν, t, μa, a, b, z0, zb), t)
+end
 
-    return Rt
+@inline function _kernel_flux_DA_semiinf_TD(D, ν, t, μa, a, b, z0, zb)
+    tmp = inv(4 * D * ν * t)
+    ϕ = z0 * exp(-a * tmp)
+    ϕ += (z0 + 2 * zb) * exp(-b * tmp)
+    ϕ *= exp(-μa * ν * t)
+    ϕ /= 2 * (4 * D * ν * π)^(3/2) * t^(5/2)
+
+    return ϕ 
 end

--- a/src/forwardmodels/Diffusion Approximation/Semi-infinite/DAsemiinf.jl
+++ b/src/forwardmodels/Diffusion Approximation/Semi-infinite/DAsemiinf.jl
@@ -83,7 +83,7 @@ Compute the time-domain fluence in a semi-infinite medium.
 - `μa`: absorption coefficient (cm⁻¹)
 - `μsp`: reduced scattering coefficient (cm⁻¹)
 
-# Optional arguments
+# Keyword arguments
 - `n_ext`: the boundary's index of refraction (air or detector)
 - `n_med`: the sample medium's index of refraction
 - `z`: the z-depth orthogonal from the boundary (cm)

--- a/src/forwardmodels/Diffusion Approximation/Semi-infinite/DAsemiinf.jl
+++ b/src/forwardmodels/Diffusion Approximation/Semi-infinite/DAsemiinf.jl
@@ -6,74 +6,6 @@
 # [2] Martelli, Fabrizio, et al. Light propagation through biological tissue and other diffusive media: theory, solutions and software. 
 #     Vol. 10. No. 3.824746. Bellingham: SPIE press, 2010.
 #----------------------------------------------------------------------------------------------------------------------------------------
-
-""" Structure containing inputs for simulating the fluence under the diffusion approximation in the semi-infinite space."""
-struct DAsemiinf_params{T <: AbstractFloat} <: DiffusionParameters
-    ρ::T                                 # distance away from isotropic point source (cm)
-    μa::T                                # absorption coefficient (cm⁻¹)
-    μsp::T                               # reduced scattering coefficient (cm⁻¹)
-    n_med::T                             # medium's index of refraction
-    n_ext::T                             # external medium's index of refraction
-    ω::T                                 # modulation frequency (1/ns)
-    z::T                                 # z depth of detector within medium (cm)
-    t::Union{T, AbstractVector{T}}       # time vector (ns)
-
-    # do not need to provide these arguments (calculated from previous inputs)
-    D::T                                 # Diffusion coefficient                        
-    ν::T                                 # Speed of light in medium (cm/ns)
-    z0::T                                # isotroptic source depth
-    zb::T                                # Extrapolation length
-    function DAsemiinf_params{T}(ρ::T, μa::T, μsp::T, n_med::T, n_ext::T, ω::T, z::T, t::Union{T, AbstractVector{T}}) where {T <: AbstractFloat}
-        @assert ρ >= zero(T) "ρ must greater than or equal to 0"
-        @assert μa >= zero(T) "μa must greater than or equal to 0"
-        @assert μsp > zero(T) "μsp must greater than 0"
-        @assert n_med > zero(T) "n_med must be positive"
-        @assert n_ext > zero(T) "n_ext must be positive"
-        @assert all(t .> zero(T)) "t must be positive"
-        D = D_coeff(μsp)
-        return new{T}(ρ, μa, μsp, n_med, n_ext, ω, z, t, D, ν_coeff(n_med), z0_coeff(μsp), zb_coeff(A_coeff(n_med / n_ext), D))
-    end
-end
-
-"""
-    Generator function for DAsemiinf_params structure.
-
-Provides default parameters to use in the semi-infinite space fluence calculation in either the CW, FD, or TD.
-
-# Keyword Arguments
-- `ρ`: source-detector separation (cm⁻¹)
-- `μa`: absorption coefficient (cm⁻¹)
-- `μsp`: reduced scattering coefficient (cm⁻¹)
-- `n_med`: medium's index of refraction
-- `n_ext`: external medium's index of refraction (air or detector)
-- `ω`: modulation frequency (1/ns)
-- `z`: the z-depth orthogonal from the boundary (cm)
-- `t`: the time vector (ns). 
-
-# Examples
-```
-julia> data = DAsemiinf_params() # return default parameters
-julia> data = DAsemiinf_params(ρ = 1.5) # return ρ = 1.5 with the rest of the parameters given by defaults
-julia> fluence_DA_semiinf_CW(data) # can then be used with corresponding functions
-```
-"""
-function DAsemiinf_params(;
-    ρ::T = 1.0,
-    μa::T = 0.1,
-    μsp::T = 10.0,
-    n_med::T = 1.0,
-    n_ext::T = 1.0,
-    ω::T = 0.0,
-    z::T = 0.0,
-    t::Union{T, AbstractVector{T}} = 1.0
-) where {T<:AbstractFloat}
-    return DAsemiinf_params{T}(ρ, μa, μsp, n_med, n_ext, ω, z, t)
-end
-
-#------------------------------
-# Steady-State Fluence 
-#------------------------------
-
 """
     fluence_DA_semiinf_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0)
 
@@ -95,33 +27,49 @@ julia> fluence_DA_semiinf_CW(1.0, 0.1, 10.0)
 julia> fluence_DA_semiinf_CW(1.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0, z = 0.0)
 ```
 """
-function fluence_DA_semiinf_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0)
-    μeff = sqrt(3 * μa * μsp)
-    D = D_coeff(μsp)
-    (z0, zb) = (z0_coeff(μsp), zb_coeff(A_coeff(n_med / n_ext), D))
-    return _kernel_fluence_DA_semiinf_CW(μeff, ρ, z, z0, zb, D)
-end
-function _kernel_fluence_DA_semiinf_CW(μeff, ρ, z, z0, zb, D)
-    a = hypot(ρ, z - z0)
-    b = hypot(ρ, z + 2 * zb + z0)
+function fluence_DA_semiinf_CW end
 
-    # the following tries to compute ϕ = exp(-μeff * a) / a - exp(-μeff * b) / b more accurately
-    # there is some loss of significance when a ≈ b and a > 5
-    # h also tries to compute h = b - a more accurately
-    h = 4 * (z0 * z + z0 * zb + z * zb + zb^2) / (a + b)
-    ϕ = exp(-b * μeff) * fma(b, expm1(h * μeff), h) / (b * a)
-    return ϕ / (4 * π * D)
-end
-function _kernel_fluence_DA_semiinf_CW(μeff::Complex, ρ, z, z0, zb, D)
-    a = hypot(ρ, z - z0)
-    b = hypot(ρ, z + 2 * zb + z0)
-    ϕ = exp(-μeff * a) / a - exp(-μeff * b) / b 
-    return ϕ / (4 * π * D)
-end
+"""
+    flux_DA_semiinf_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0)
 
-#------------------------------
-# Time-Domain Fluence 
-#------------------------------
+Compute the steady-state flux (D*∂ϕ(ρ)/∂z @ z = 0) from a semi-infinite medium.
+
+# Arguments
+- `ρ`: the source detector separation (cm⁻¹)
+- `μa`: absorption coefficient (cm⁻¹)
+- `μsp`: reduced scattering coefficient (cm⁻¹)
+- `ndet`: the boundary's index of refraction (air or detector)
+- `nmed`: the sample medium's index of refraction
+
+# Examples
+```
+julia> flux_DA_semiinf_CW(1.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0)
+```
+"""
+function flux_DA_semiinf_CW end
+
+"""
+fluence_DA_semiinf_FD(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0, ω = 1.0)
+
+Compute the frequency domain fluence in a semi-infinite geometry.
+
+# Arguments
+- `ρ`: the source detector separation (cm⁻¹)
+- `μa`: absorption coefficient (cm⁻¹)
+- `μsp`: reduced scattering coefficient (cm⁻¹)
+
+# Keyword arguments
+- `n_ext`: the boundary's index of refraction (air or detector)
+- `n_med`: the sample medium's index of refraction
+- `z`: the z-depth orthogonal from the boundary (cm)
+- `ω`: the modulation frequency (1/ns)
+
+# Examples
+```
+julia> fluence_DA_semiinf_FD(1.0, 0.1, 10.0; n_ext = 1.0, n_med = 1.0, z = 0.0, ω = 1.0)
+```
+"""
+function fluence_DA_semiinf_FD end
 
 """
     fluence_DA_semiinf_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0)
@@ -145,67 +93,8 @@ julia> fluence_DA_semiinf_TD(0.1:0.1:2.0, 1.0, 0.1, 10.0)
 julia> fluence_DA_semiinf_TD(0.2:0.2:1.0, 1.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0, z = 0.0)
 ```
 """
-function fluence_DA_semiinf_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0)
-    params = DiffusionKernelParams(μsp, n_med, n_ext)
-    return map(t -> _kernel_fluence_DA_semiinf_TD(params.D, params.ν, t, μa, z, params.z0, ρ, params.zb), t)
-end
+function fluence_DA_semiinf_TD end
 
-"""
-    fluence_DA_semiinf_TD(t, data::DiffusionParameters)
-
-Wrapper to `fluence_DA_semiinf_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0)`
-
-# Examples
-```
-julia> data = DAsemiinf_params() # use structure to generate inputs
-julia> fluence_DA_semiinf_TD(data) # then call the function
-```
-"""
-function fluence_DA_semiinf_TD(data::DiffusionParameters)
-    return map(t -> _kernel_fluence_DA_semiinf_TD(data.D, data.ν, t, data.μa, data.z, data.z0, data.ρ, data.zb), data.t)
-end
-
-@inline function _kernel_fluence_DA_semiinf_TD(D, ν, t, μa, z, z0, ρ, zb)
-    tmp1 = 4 * D * ν * t
-    ϕ = ν * exp(-μa * ν * t) / (π * tmp1)^(3/2)
-    ϕ *= (exp(-((z - z0)^2 + ρ^2) / tmp1) - exp(-((z + z0 + 2*zb)^2 + ρ^2) / tmp1))
-    return ϕ
-end
-
-#------------------------------
-# Frequency-Domain Fluence 
-#------------------------------
-"""
-fluence_DA_semiinf_FD(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0, ω = 1.0)
-
-Compute the frequency domain fluence in a semi-infinite geometry.
-
-# Arguments
-- `ρ`: the source detector separation (cm⁻¹)
-- `μa`: absorption coefficient (cm⁻¹)
-- `μsp`: reduced scattering coefficient (cm⁻¹)
-
-# Keyword arguments
-- `n_ext`: the boundary's index of refraction (air or detector)
-- `n_med`: the sample medium's index of refraction
-- `z`: the z-depth orthogonal from the boundary (cm)
-- `ω`: the modulation frequency (1/ns)
-
-# Examples
-```
-julia> fluence_DA_semiinf_FD(1.0, 0.1, 10.0; n_ext = 1.0, n_med = 1.0, z = 0.0, ω = 1.0)
-```
-"""
-function fluence_DA_semiinf_FD(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0, ω = 1.0)
-    params = DiffusionKernelParams(μsp, n_med, n_ext)
-    μa_complex = μa + ω * im / params.ν
-    μeff = sqrt(3 * μa_complex * μsp)
-    return _kernel_fluence_DA_semiinf_CW(μeff, ρ, z, params.z0, params.zb, params.D)
-end
-
-#------------------------------
-# Time-Domain Flux
-#------------------------------
 """
     flux_DA_semiinf_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0)
 
@@ -226,32 +115,93 @@ Compute the time-domain flux (D*∂ϕ(t)/∂z @ z = 0) from a semi-infinite medi
 julia> flux_DA_semiinf_TD(0.1:0.1:2.0, 1.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0)
 ```
 """
-function flux_DA_semiinf_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0)
-    params = DiffusionKernelParams(μsp, n_med, n_ext)
-    z3m = - params.z0
-    z4m = 2 * params.zb + params.z0
+function flux_DA_semiinf_TD end
 
-    return map(t -> _kernel_flux_DA_semiinf_TD(params.D, params.ν, t, μa, z3m, z4m, ρ), t)
- end
+#------------------------------
+# Steady-State Fluence 
+#------------------------------
 
- """
-    flux_DA_semiinf_TD(t, data::DiffusionParameters)
+function fluence_DA_semiinf_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0)
+    μeff = sqrt(3 * μa * μsp)
+    D, A = D_coeff(μsp), A_coeff(n_med / n_ext)
+    z0, zb = z0_coeff(μsp), zb_coeff(A, D)
+    return _kernel_fluence_DA_semiinf_CW(μeff, ρ, z, z0, zb, D)
+end
+function _kernel_fluence_DA_semiinf_CW(μeff, ρ, z, z0, zb, D)
+    a = hypot(ρ, z - z0)
+    b = hypot(ρ, z + 2 * zb + z0)
 
-Wrapper to `flux_DA_semiinf_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0)`
-
-# Examples
-```
-julia> data = DAsemiinf_params() # use structure to generate inputs
-julia> flux_DA_semiinf_TD(data) # then call the function
-```
-"""
-function flux_DA_semiinf_TD(data::DiffusionParameters)
-    z3m = - data.z0
-    z4m = 2 * data.zb + data.z0
-
-    return map(t -> _kernel_flux_DA_semiinf_TD(data.D, data.ν, t, data.μa, z3m, z4m, data.ρ), data.t)
+    # the following tries to compute ϕ = exp(-μeff * a) / a - exp(-μeff * b) / b more accurately
+    # there is some loss of significance when a ≈ b and a > 5
+    # h also tries to compute h = b - a more accurately
+    h = 4 * (z0 * z + z0 * zb + z * zb + zb^2) / (a + b)
+    ϕ = exp(-b * μeff) * fma(b, expm1(h * μeff), h) / (b * a)
+    return ϕ / (4 * π * D)
+end
+function _kernel_fluence_DA_semiinf_CW(μeff::Complex, ρ, z, z0, zb, D)
+    a = hypot(ρ, z - z0)
+    b = hypot(ρ, z + 2 * zb + z0)
+    ϕ = exp(-μeff * a) / a - exp(-μeff * b) / b 
+    return ϕ / (4 * π * D)
 end
 
+#------------------------------
+# Steady-State Flux
+#------------------------------
+
+function flux_DA_semiinf_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0)
+    D = D_coeff(μsp)
+    return D * ForwardDiff.derivative(z -> fluence_DA_semiinf_CW(ρ, μa, μsp, n_med = n_med, n_ext = n_ext, z = z), 0.0)
+end
+
+#------------------------------
+# Frequency-Domain Fluence 
+#------------------------------
+
+function fluence_DA_semiinf_FD(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0, ω = 1.0)
+    D, A, ν = D_coeff(μsp), A_coeff(n_med / n_ext), ν_coeff(n_med)
+    z0, zb = z0_coeff(μsp), zb_coeff(A, D)
+
+    μa_complex = μa + ω * im / ν
+    μeff = sqrt(3 * μa_complex * μsp)
+    return _kernel_fluence_DA_semiinf_CW(μeff, ρ, z, z0, zb, D)
+end
+
+#------------------------------
+# Time-Domain Fluence 
+#------------------------------
+
+function fluence_DA_semiinf_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0, z = 0.0)
+    T = eltype(ρ)
+    D, A, ν = D_coeff(μsp), A_coeff(n_med / n_ext), ν_coeff(n_med)
+    z0, zb = z0_coeff(μsp), zb_coeff(A, D)
+
+    b = ρ^2 + (z + z0 + 2zb)^2
+    h = 4 * (z * z0 + z * zb + zb^2 + z0 * zb)
+    ϕ = ν * inv(T(pi)^(1.5))
+
+    return map(t -> _kernel_fluence_DA_semiinf_TD(ϕ, b, h, D, ν, t, μa), t)
+end
+@inline function _kernel_fluence_DA_semiinf_TD(ϕ, b, h, D, ν, t, μa)
+    tmp1 = inv(4 * D * ν * t)
+    ϕ *= exp(-μa * ν * t) * tmp1^(1.5)
+    ϕ *= exp(-b * tmp1) * expm1(tmp1 * h)
+    return ϕ
+end
+
+#------------------------------
+# Time-Domain Flux
+#------------------------------
+
+function flux_DA_semiinf_TD(t, ρ, μa, μsp; n_ext = 1.0, n_med = 1.0)
+    D, A, ν = D_coeff(μsp), A_coeff(n_med / n_ext), ν_coeff(n_med)
+    z0, zb = z0_coeff(μsp), zb_coeff(A, D)
+
+    z3m = -z0
+    z4m = 2 * zb + z0
+
+    return map(t -> _kernel_flux_DA_semiinf_TD(D, ν, t, μa, z3m, z4m, ρ), t)
+ end
 @inline function _kernel_flux_DA_semiinf_TD(D, ν, t, μa, z3m, z4m, ρ)
     tmp1 = 4 * D * ν * t
     Rt = -(ρ^2 / (tmp1))
@@ -260,44 +210,4 @@ end
     Rt *= (z3m * exp(-(z3m^2 / (tmp1))) - z4m * exp(-(z4m^2 / (tmp1))))
 
     return Rt
-end
-
-#------------------------------
-# Steady-State Flux
-#------------------------------
-"""
-    flux_DA_semiinf_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0)
-
-Compute the steady-state flux (D*∂ϕ(ρ)/∂z @ z = 0) from a semi-infinite medium.
-
-# Arguments
-- `ρ`: the source detector separation (cm⁻¹)
-- `μa`: absorption coefficient (cm⁻¹)
-- `μsp`: reduced scattering coefficient (cm⁻¹)
-- `ndet`: the boundary's index of refraction (air or detector)
-- `nmed`: the sample medium's index of refraction
-
-# Examples
-```
-julia> flux_DA_semiinf_CW(1.0, 0.1, 10.0, n_ext = 1.0, n_med = 1.0)
-```
-"""
-function flux_DA_semiinf_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0)
-    D = D_coeff(μsp)
-    return D * ForwardDiff.derivative(z -> fluence_DA_semiinf_CW(ρ, μa, μsp, n_med = n_med, n_ext = n_ext, z = z), 0.0)
-end
-
-"""
-    flux_DA_semiinf_CW(data::DiffusionParameters)
-
-Wrapper to `flux_DA_semiinf_CW(ρ, μa, μsp; n_ext = 1.0, n_med = 1.0)`
-
-# Examples
-```
-julia> data = DAsemiinf_params(ρ = 1.0) # use structure to generate inputs
-julia> flux_DA_semiinf_CW(data) # then call the function
-```
-"""
-function flux_DA_semiinf_CW(data)
-    return flux_DA_semiinf_CW(data.ρ, data.μa, data.μsp, n_ext = data.n_ext, n_med = data.n_med)
 end


### PR DESCRIPTION
This looks to improve the accuracy of the implementation of the semi-inf solutions. Here is an example of the TD fluence error improvement..
<img width="755" alt="Screen Shot 2022-04-21 at 11 54 05 AM" src="https://user-images.githubusercontent.com/57471570/164501252-23cede2b-8ef6-4f3d-9117-a8ec8e9d29c9.png">
.

I've also taken out the structure implementations and input checks. I think this just confuses the overall source code and is hardly used. 