### PR TITLE
Update hyperbola

### DIFF
--- a/src/forwardmodels/Diffusion Approximation/DAcylinder_layered.jl
+++ b/src/forwardmodels/Diffusion Approximation/DAcylinder_layered.jl
@@ -331,7 +331,7 @@ julia> flux_DA_Nlay_cylinder_TD(0.1:0.2:1.2, 1.0, (0.2, 0.1, 0.2), (12.0, 10.0, 
 function flux_DA_Nlay_cylinder_TD(t::AbstractVector, ρ, μa, μsp; n_ext=1.0, n_med=(1.0, 1.0), l=(1.0, 5.0), a=10.0, z=0.0, MaxIter=10000, atol=eps(Float64), N = 24)
     @assert z == zero(eltype(z)) || z == sum(l)
     D = D_coeff.(μsp)
-
+    
     ## need to know the type of z to preallocate vectors coorectly in hyper_fixed for autodiff
     function _ILT(z::T) where {T} 
         return hyper_fixed(s -> _fluence_DA_Nlay_cylinder_Laplace(ρ, μa, μsp, n_ext, n_med, l, a, z, s, MaxIter, atol), t, N = N, T = T)

--- a/src/forwardmodels/Diffusion Approximation/transforms.jl
+++ b/src/forwardmodels/Diffusion Approximation/transforms.jl
@@ -134,10 +134,9 @@ julia> InverseLaplace.hyper_fixed!(out, s -> 1/(s + 1), t)
  0.16529888822160033
  0.13533528323663216
 """
-function hyper_fixed!(out::AbstractVector{T}, f::Function, t::AbstractVector{T}; N::Int = 24) where T
+function hyper_fixed!(out, f::Function, t::AbstractVector{T}; N::Int = 24) where T
     length(out) == length(t) || throw(DimensionMismatch("out is not equal to length of t"))
     iszero(out) || throw(ArgumentError("out is not a vector of zeros"))
-
     μ, h = hyper_coef(N, t)
 
     Threads.@threads for k in 0:N-1


### PR DESCRIPTION
This gives some speed gains and simplifies the code for the inverse laplace transform. 

```julia
julia> @benchmark fluence_DA_Nlay_cylinder_TD(0.1:0.1:1.0, 1.0, (0.1, 0.2), (23.0, 14.0), MaxIter=600, N = 8)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  210.791 μs …  10.130 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     261.459 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   266.710 μs ± 150.423 μs  ┊ GC (mean ± σ):  0.13% ± 0.89%

           ▂▅▅█▆▆▄▅▃▄▂▃▄▄▄▆▄▄▅▅▃▃▃▃▂▁▂▁                          
  ▁▂▂▂▃▅▆▇█████████████████████████████▇▇▆▆▅▅▅▄▄▄▃▃▃▃▃▃▃▃▂▂▂▂▂▂ ▅
  211 μs           Histogram: frequency by time          338 μs <

 Memory estimate: 5.75 KiB, allocs estimate: 50.

julia> @benchmark fluence_DA_Nlay_cylinder_TD(0.1:0.1:1.0, 1.0, (0.1, 0.2), (23.0, 14.0), MaxIter=600, N = 16)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  378.792 μs …  4.362 ms  ┊ GC (min … max): 0.00% … 86.13%
 Time  (median):     447.062 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   450.617 μs ± 51.675 μs  ┊ GC (mean ± σ):  0.08% ±  0.86%

              ▂▃▃▄▅▆▆█▇▆▆▇▄▇▃▅▁▂▁                               
  ▁▁▂▃▃▄▅▆▇██▇████████████████████▆▆▆▅▄▄▃▃▂▂▂▂▂▂▁▂▁▂▂▁▂▁▁▁▁▁▁▁ ▄
  379 μs          Histogram: frequency by time          569 μs <

 Memory estimate: 5.75 KiB, allocs estimate: 50.
```